### PR TITLE
feat: Move item history to sidebar drawer & Refactor Invoice Header

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -3,10 +3,8 @@
 class VersionsController < ApplicationController
   layout "settings"
 
-  def index # rubocop:disable Metrics/AbcSize
+  def index
     @versions = policy_scope(Version, policy_scope_class: VersionPolicy::Scope)
-    @versions = @versions.where(item_type: params[:item_type]) if params[:item_type].present?
-    @versions = @versions.where(item_id: params[:item_id]) if params[:item_id].present?
     @q = @versions.ransack(params[:q])
     @q.sorts = "created_at desc" if @q.sorts.empty?
     @versions = @q.result.page(params[:page]).per(20)

--- a/app/views/shared/_item_history.html.haml
+++ b/app/views/shared/_item_history.html.haml
@@ -43,4 +43,4 @@
 
   - if item.versions.count > 10
     .text-center.mt-2
-      = link_to t("shared.item_history.view_all", count: item.versions.count), versions_path(item_type: item.class.name, item_id: item.id), class: "btn btn-sm btn-ghost"
+      = link_to t("shared.item_history.view_all", count: item.versions.count), versions_path(q: { item_type_eq: item.class.name, item_id_eq: item.id }), class: "btn btn-sm btn-ghost"


### PR DESCRIPTION
## Changes

- **Move History to Sidebar**: Replaced the inline item history table with a sidebar drawer on `Invoices`, `Leases`, `Owners`, `Properties`, `Tenants`, and `Users` show pages.
- **UI Improvements**:
  - Added a 'History' toggle button (icon-only clock) to the page headers.
  - Refactored `invoices/show` header layout to a clean 2-row design (Title/History & Details/Owner).
- **Code Cleanup**:
  - Removed unused `_item_history` partial.
  - Cleaned up unused i18n keys.
  - Added `clock` icon to `IconHelper`.

## Verification
- Verified all show pages render correctly.
- Verified history drawer toggles correctly.
- RSpec tests passed.
- i18n-tasks checks passed.