### PR TITLE
fix: Property strong params, form layout, and optional validations

### DIFF
--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -52,6 +52,6 @@ class PropertiesController < ApplicationController
   private
 
   def property_params
-    params.expect(property: %i[name address owner_id])
+    params.expect(property: %i[name address owner_id capacity unit])
   end
 end

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -6,7 +6,6 @@ class Owner < ApplicationRecord
   has_many :users, through: :user_associations
 
   validates :name, presence: true
-  validates :address, presence: true
   validates :invoice_sequence, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :credit_note_sequence, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -6,7 +6,6 @@ class Property < ApplicationRecord
   has_many :leases, dependent: :destroy
 
   validates :name, presence: true
-  validates :address, presence: true
   validates :capacity, presence: true, numericality: { greater_than: 0, only_integer: true }
   validates :unit, presence: true
 

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -6,6 +6,4 @@ class Tenant < ApplicationRecord
   has_many :users, through: :user_associations
 
   validates :name, presence: true
-  validates :email, presence: true
-  validates :phone_number, presence: true
 end

--- a/app/views/properties/_form.html.haml
+++ b/app/views/properties/_form.html.haml
@@ -10,7 +10,9 @@
     .col-span-1.md:col-span-2
       = f.input :address, as: :text, input_html: { rows: 3 }
 
-    = f.input :capacity, hint: "Total capacity available for leasing"
-    = f.input :unit, hint: "Unit of capacity (e.g., Rooms, Desks, Seats)"
+    .col-span-1
+      = f.input :capacity, hint: "Total capacity available for leasing"
+    .col-span-1
+      = f.input :unit, hint: "Unit of capacity (e.g., Rooms, Desks, Seats)"
 
   = f.form_actions

--- a/spec/models/owner_spec.rb
+++ b/spec/models/owner_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Owner do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:name) }
-    it { is_expected.to validate_presence_of(:address) }
     it { is_expected.to validate_numericality_of(:invoice_sequence).only_integer.is_greater_than_or_equal_to(0) }
     it { is_expected.to validate_numericality_of(:credit_note_sequence).only_integer.is_greater_than_or_equal_to(0) }
   end

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Property do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:name) }
-    it { is_expected.to validate_presence_of(:address) }
     it { is_expected.to validate_presence_of(:capacity) }
     it { is_expected.to validate_numericality_of(:capacity).only_integer.is_greater_than(0) }
     it { is_expected.to validate_presence_of(:unit) }

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -12,7 +12,5 @@ RSpec.describe Tenant do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:name) }
-    it { is_expected.to validate_presence_of(:email) }
-    it { is_expected.to validate_presence_of(:phone_number) }
   end
 end

--- a/spec/requests/properties_spec.rb
+++ b/spec/requests/properties_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe "Properties" do
   describe "POST /properties" do
     context "with valid parameters" do
       let(:owner) { create(:owner) }
-      let(:valid_attributes) { { name: "Sunset Villa", address: "123 Sunset Blvd", owner_id: owner.id } }
+      let(:valid_attributes) do
+        { name: "Sunset Villa", address: "123 Sunset Blvd", owner_id: owner.id, capacity: 10, unit: "Rooms" }
+      end
 
       it "creates a new Property" do
         expect do


### PR DESCRIPTION
## Summary
- Add `capacity` and `unit` to property strong params — these fields were in the form but silently ignored on submit.
- Wrap capacity/unit form inputs in `.col-span-1` divs to fix overlapping labels and hints in the property form.
- Make email and phone_number optional on Tenant model.
- Make address optional on Property and Owner models.

## Test plan
- [x] All 549 specs pass
- [ ] Verify property capacity and unit can be set/edited via the form
- [ ] Verify property form renders capacity/unit side-by-side without overlap
- [ ] Verify tenants can be created without email or phone number
- [ ] Verify properties and owners can be created without address

🤖 Generated with [Claude Code](https://claude.com/claude-code)