### PR TITLE
fix: Allow decimal values for security deposit in months

### DIFF
--- a/app/models/concerns/lease/rent_calculation.rb
+++ b/app/models/concerns/lease/rent_calculation.rb
@@ -10,7 +10,7 @@ class Lease
       validates :rent_amount, presence: true, numericality: { greater_than: 0 }
       validates :enhancement_period_months, presence: true, numericality: { only_integer: true, greater_than: 0 }
       validates :security_deposit_in_months, presence: true,
-                                             numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+                                             numericality: { greater_than_or_equal_to: 0 }
       validates :enhancement_amount, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
       validates :tax_rate, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }, allow_nil: true
     end

--- a/db/migrate/20260209170745_change_security_deposit_in_months_to_decimal.rb
+++ b/db/migrate/20260209170745_change_security_deposit_in_months_to_decimal.rb
@@ -1,0 +1,5 @@
+class ChangeSecurityDepositInMonthsToDecimal < ActiveRecord::Migration[8.1]
+  def change
+    change_column :leases, :security_deposit_in_months, :decimal, precision: 5, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_09_165402) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_09_170745) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -79,7 +79,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_09_165402) do
     t.integer "quantity", default: 1, null: false
     t.bigint "renewed_from_id"
     t.decimal "rent_amount"
-    t.integer "security_deposit_in_months"
+    t.decimal "security_deposit_in_months", precision: 5, scale: 2
     t.date "start_date"
     t.string "tax_name"
     t.decimal "tax_rate", precision: 5, scale: 2


### PR DESCRIPTION
## Summary
- Change `security_deposit_in_months` column from integer to decimal(5,2) to support fractional values like 1.5 months.
- Remove `only_integer` constraint from the validation.

## Test plan
- [x] All 549 specs pass
- [ ] Verify entering a decimal value (e.g. 1.5) for security deposit in months saves correctly
- [ ] Verify security deposit amount calculates correctly with decimal months (e.g. 1000 rent * 1.5 months = 1500)