### PR TITLE
fix: Show all invoices per month and Generate button for missing rental

### DIFF
--- a/app/controllers/leases_controller.rb
+++ b/app/controllers/leases_controller.rb
@@ -7,7 +7,7 @@ class LeasesController < ApplicationController
   end
 
   def show
-    @lease = Lease.find(params[:id])
+    @lease = Lease.includes(invoices: :line_items).find(params[:id])
     authorize @lease
   end
 

--- a/app/views/leases/show.html.haml
+++ b/app/views/leases/show.html.haml
@@ -113,15 +113,26 @@
                 %th
             %tbody
               - billable_months(@lease).reverse.each do |month|
-                - invoice = @lease.invoices.find { |i| i.date.beginning_of_month == month }
-                - if invoice
-                  %tr.hover.cursor-pointer{data: { controller: "clickable-row", clickable_row_url_value: invoice_path(invoice), action: "click->clickable-row#click" }}
-                    %td= link_to month.strftime("%B %Y"), invoice, class: "link link-hover font-medium"
-                    %td
-                      %span.resource-badge{class: "resource-badge-#{invoice.paid? ? 'success' : invoice.draft? ? 'neutral' : 'info'}"}
-                        = invoice.status.humanize
-                    %td.text-right= number_to_currency(invoice.total_amount, unit: "₹", precision: 0)
-                    %td
+                - invoices = @lease.invoices.select { |i| i.date.beginning_of_month == month }
+                - has_rental = invoices.any? { |i| i.line_items.any? { |li| li.category == "rent" } }
+                - if invoices.any?
+                  - invoices.each do |invoice|
+                    %tr.hover.cursor-pointer{data: { controller: "clickable-row", clickable_row_url_value: invoice_path(invoice), action: "click->clickable-row#click" }}
+                      %td= link_to month.strftime("%B %Y"), invoice, class: "link link-hover font-medium"
+                      %td
+                        %span.resource-badge{class: "resource-badge-#{invoice.paid? ? 'success' : invoice.draft? ? 'neutral' : 'info'}"}
+                          = invoice.status.humanize
+                      %td.text-right= number_to_currency(invoice.total_amount, unit: "₹", precision: 0)
+                      %td
+                  - unless has_rental
+                    %tr
+                      %td= month.strftime("%B %Y")
+                      %td
+                        %span.resource-badge.resource-badge-warning Missing rental
+                      %td.text-right -
+                      %td
+                        - if policy(Invoice.new(lease: @lease)).new?
+                          = link_to "Generate", new_invoice_path(lease_id: @lease.id, date: month.to_s), class: "btn btn-xs btn-primary"
                 - else
                   %tr
                     %td= month.strftime("%B %Y")


### PR DESCRIPTION
## Summary
- Fixed invoice table on lease show page to display **all** invoices for each month (e.g., security deposit + rent) instead of only the first match
- Show "Generate" button when no **rental** invoice exists for a month, even if other invoices (e.g., security deposit) are present
- Eager load `invoices: :line_items` in controller to avoid N+1 queries

## Test plan
- [x] `bundle exec rspec` — all 554 specs pass
- [ ] Manual: Lease with first-month security deposit + rent shows both invoices
- [ ] Manual: Month with only security deposit shows Generate button

🤖 Generated with [Claude Code](https://claude.com/claude-code)