### PR TITLE
fix: Include tax in invoice total_amount calculations

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -7,7 +7,10 @@ class Invoice < ApplicationRecord
   has_many :entries, as: :instrument, dependent: :destroy
 
   ransacker :total_amount do
-    Arel.sql("(SELECT COALESCE(SUM(line_items.amount), 0) FROM line_items WHERE line_items.invoice_id = invoices.id)")
+    Arel.sql(<<~SQL.squish)
+      (SELECT COALESCE(SUM(line_items.amount + line_items.amount * COALESCE(line_items.tax_rate, 0) / 100.0), 0)
+       FROM line_items WHERE line_items.invoice_id = invoices.id)
+    SQL
   end
 
   enum :status, { draft: 0, finalized: 1, sent: 2, paid: 3, cancelled: 4, partially_paid: 5 }, default: :draft,
@@ -25,7 +28,7 @@ class Invoice < ApplicationRecord
   scope :rental, -> { joins(:line_items).where(line_items: { category: "rent" }).distinct }
 
   def total_amount
-    line_items.sum(:amount)
+    line_items.sum("ROUND(amount + amount * COALESCE(tax_rate, 0) / 100.0, 2)")
   end
 
   def paid_amount

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Invoice do
 
       before do
         invoice.line_items.destroy_all
-        create(:line_item, invoice: invoice, amount: 100)
+        create(:line_item, invoice: invoice, amount: 100, tax_rate: nil)
       end
 
       it "creates an initial entry when finalized" do
@@ -83,7 +83,7 @@ RSpec.describe Invoice do
     describe "auto settlement" do
       before do
         invoice.line_items.destroy_all
-        create(:line_item, invoice: invoice, amount: 100)
+        create(:line_item, invoice: invoice, amount: 100, tax_rate: nil)
       end
 
       it "auto-settles after save when finalizing" do
@@ -113,12 +113,34 @@ RSpec.describe Invoice do
     end
   end
 
+  describe "#total_amount" do
+    let(:invoice) { create(:invoice, status: :draft) }
+
+    before { invoice.line_items.destroy_all }
+
+    it "sums line item amounts when no tax" do
+      create(:line_item, invoice: invoice, amount: 100, tax_rate: nil)
+      expect(invoice.total_amount).to eq(100)
+    end
+
+    it "includes tax in the total" do
+      create(:line_item, invoice: invoice, amount: 100, tax_rate: 18)
+      expect(invoice.total_amount).to eq(118)
+    end
+
+    it "sums multiple line items with mixed tax rates" do
+      create(:line_item, invoice: invoice, amount: 1000, tax_rate: 18)
+      create(:line_item, invoice: invoice, amount: 500, tax_rate: nil)
+      expect(invoice.total_amount).to eq(1680)
+    end
+  end
+
   describe "#signed_amount" do
     let(:invoice) { create(:invoice, status: :draft) }
 
     before do
       invoice.line_items.destroy_all
-      create(:line_item, invoice: invoice, amount: 100)
+      create(:line_item, invoice: invoice, amount: 100, tax_rate: nil)
     end
 
     it "returns positive amount for regular invoices" do
@@ -151,7 +173,7 @@ RSpec.describe Invoice do
 
     before do
       invoice.line_items.destroy_all
-      create(:line_item, invoice: invoice, amount: 100)
+      create(:line_item, invoice: invoice, amount: 100, tax_rate: nil)
       invoice.update!(status: :finalized)
     end
 
@@ -172,7 +194,7 @@ RSpec.describe Invoice do
 
     before do
       invoice.line_items.destroy_all
-      create(:line_item, invoice: invoice, amount: 100)
+      create(:line_item, invoice: invoice, amount: 100, tax_rate: nil)
       invoice.update!(status: :finalized)
       invoice.entries.destroy_all # Clear for manual testing
     end

--- a/spec/services/settlement_service_spec.rb
+++ b/spec/services/settlement_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SettlementService do
     invoice = create(:invoice, lease: lease, date: date, status: :draft, document_type: document_type)
     invoice.line_items.destroy_all
     # All line_items store positive amounts - document_type determines sign
-    create(:line_item, invoice: invoice, amount: amount.abs)
+    create(:line_item, invoice: invoice, amount: amount.abs, tax_rate: nil)
     # Manually set status to trigger entry creation
     invoice.update!(status: status)
     invoice.reload

--- a/spec/views/invoices/index.html.haml_spec.rb
+++ b/spec/views/invoices/index.html.haml_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "invoices/index" do
 
   before do
     invoice = create(:invoice)
-    create(:line_item, invoice: invoice, amount: 1000)
+    create(:line_item, invoice: invoice, amount: 1000, tax_rate: nil)
     assign(:invoices, Invoice.where(id: invoice.id).page(1))
     assign(:q, Invoice.ransack(nil))
     render


### PR DESCRIPTION
## Summary
- `Invoice#total_amount` now includes tax (`amount + amount * tax_rate / 100`) instead of summing only base amounts
- Updated `ransacker :total_amount` with matching SQL so Ransack sorting/filtering also reflects tax-inclusive totals
- Invoice amounts on the lease page now match invoice detail page totals

## Test plan
- [x] `bundle exec rspec` — all 557 specs pass (3 new)
- [ ] Manual: Invoice amounts on lease page match invoice detail page totals (including tax)

🤖 Generated with [Claude Code](https://claude.com/claude-code)