### PR TITLE
fix: Browser tab shows page title instead of generic app name

### DIFF
--- a/app/views/invoices/edit.html.haml
+++ b/app/views/invoices/edit.html.haml
@@ -1,3 +1,4 @@
+- content_for :title, @invoice.credit_note? ? "Edit Credit Note" : "Edit Invoice"
 .max-w-4xl.mx-auto.card.bg-base-100.shadow-xl
   .card-body
     %h2.card-title.mb-5= @invoice.credit_note? ? "Edit Credit Note" : "Edit Invoice"

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title, "Invoices"
+- content_for :title, "Invoices"
 
 - content_for :page_actions do
   -# View toggle (desktop only)

--- a/app/views/invoices/new.html.haml
+++ b/app/views/invoices/new.html.haml
@@ -1,3 +1,4 @@
+- content_for :title, @invoice.credit_note? ? "New Credit Note" : "New Invoice"
 .max-w-4xl.mx-auto.card.bg-base-100.shadow-xl
   .card-body
     %h2.card-title.mb-5= @invoice.credit_note? ? "New Credit Note" : "New Invoice"

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title do
+- content_for :title do
   = @invoice.credit_note? ? "Credit Note" : "Invoice"
   - if @invoice.number.present?
     = " ##{@invoice.number}"

--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -1,5 +1,5 @@
 %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
-%title= content_for(:title) || Rails.application.name.titleize
+%title= strip_tags(content_for(:title))&.squish.presence || Rails.application.name.titleize
 %meta{:content => "width=device-width,initial-scale=1", :name => "viewport"}/
 %meta{:content => "yes", :name => "apple-mobile-web-app-capable"}/
 %meta{:content => "yes", :name => "mobile-web-app-capable"}/

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -16,7 +16,7 @@
 
           -# Page header (title + actions)
           .page-header
-            %h1.page-title= yield(:page_title).presence || "Home"
+            %h1.page-title= yield(:title).presence || "Home"
             .page-actions
               = yield(:page_actions)
 

--- a/app/views/leases/edit.html.haml
+++ b/app/views/leases/edit.html.haml
@@ -1,3 +1,4 @@
+- content_for :title, "Edit Lease"
 .max-w-4xl.mx-auto.card.bg-base-100.shadow-xl
   .card-body
     %h2.card-title.mb-5 Editing Lease

--- a/app/views/leases/index.html.haml
+++ b/app/views/leases/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title, "Leases"
+- content_for :title, "Leases"
 
 - content_for :page_actions do
   -# View toggle (desktop only)

--- a/app/views/leases/new.html.haml
+++ b/app/views/leases/new.html.haml
@@ -1,3 +1,4 @@
+- content_for :title, "New Lease"
 .max-w-4xl.mx-auto.card.bg-base-100.shadow-xl
   .card-body
     %h2.card-title.mb-5 New Lease

--- a/app/views/leases/show.html.haml
+++ b/app/views/leases/show.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title do
+- content_for :title do
   = "#{@lease.property.name} → #{@lease.tenant.name}"
 
 - content_for :page_actions do

--- a/app/views/owners/edit.html.haml
+++ b/app/views/owners/edit.html.haml
@@ -1,3 +1,4 @@
+- content_for :title, "Edit Owner"
 .max-w-lg.mx-auto
   %h2.text-xl.font-bold.mb-5 Edit Owner
   = render 'form'

--- a/app/views/owners/index.html.haml
+++ b/app/views/owners/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title, "Owners"
+- content_for :title, "Owners"
 
 - content_for :page_actions do
   -# View toggle (desktop only)

--- a/app/views/owners/new.html.haml
+++ b/app/views/owners/new.html.haml
@@ -1,3 +1,4 @@
+- content_for :title, "New Owner"
 .max-w-lg.mx-auto
   %h2.text-xl.font-bold.mb-5 New Owner
   = render 'form'

--- a/app/views/owners/show.html.haml
+++ b/app/views/owners/show.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title, @owner.name
+- content_for :title, @owner.name
 
 - content_for :page_actions do
   - if policy(@owner).edit?

--- a/app/views/payments/index.html.haml
+++ b/app/views/payments/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title, "Payments"
+- content_for :title, "Payments"
 
 - content_for :page_actions do
   -# View toggle (desktop only)

--- a/app/views/payments/new.html.haml
+++ b/app/views/payments/new.html.haml
@@ -1,3 +1,4 @@
+- content_for :title, @payment.refund? ? "Record Refund" : "Record Payment"
 .max-w-4xl.mx-auto.card.bg-base-100.shadow-xl
   .card-body
     %h2.card-title.mb-5= @payment.refund? ? "Record Refund" : "Record Payment"

--- a/app/views/payments/show.html.haml
+++ b/app/views/payments/show.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title do
+- content_for :title do
   = @payment.refund? ? "Refund" : "Payment"
   %span.text-base.font-normal.opacity-60.ml-2= @payment.date.strftime("%b %d, %Y")
   - if @payment.draft?

--- a/app/views/properties/edit.html.haml
+++ b/app/views/properties/edit.html.haml
@@ -1,3 +1,4 @@
+- content_for :title, "Edit Property"
 .max-w-lg.mx-auto
   %h2.text-xl.font-bold.mb-5 Editing Property
   = render 'form', property: @property

--- a/app/views/properties/index.html.haml
+++ b/app/views/properties/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title, "Properties"
+- content_for :title, "Properties"
 
 - content_for :page_actions do
   -# View toggle (desktop only)

--- a/app/views/properties/new.html.haml
+++ b/app/views/properties/new.html.haml
@@ -1,3 +1,4 @@
+- content_for :title, "New Property"
 .max-w-lg.mx-auto
   %h2.text-xl.font-bold.mb-5 New Property
   = render 'form', property: @property

--- a/app/views/properties/show.html.haml
+++ b/app/views/properties/show.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title, @property.name
+- content_for :title, @property.name
 
 - content_for :page_actions do
   - if policy(@property).edit?

--- a/app/views/reports/index.html.haml
+++ b/app/views/reports/index.html.haml
@@ -1,5 +1,4 @@
-- content_for :title, "Financial Dashboard"
-- content_for :page_title, "Overview"
+- content_for :title, "Overview"
 
 .space-y-6
 

--- a/app/views/reports/outstanding.html.haml
+++ b/app/views/reports/outstanding.html.haml
@@ -1,5 +1,4 @@
-- content_for :title, "Outstanding Report"
-- content_for :page_title, "Outstanding"
+- content_for :title, "Outstanding"
 
 .flex.justify-end.mb-6
   = link_to reports_path, class: "btn btn-ghost btn-sm gap-2" do

--- a/app/views/reports/revenue.html.haml
+++ b/app/views/reports/revenue.html.haml
@@ -1,5 +1,4 @@
 - content_for :title, "Revenue Report"
-- content_for :page_title, "Revenue Report"
 
 .flex.justify-end.mb-6
   = link_to reports_path, class: "btn btn-ghost btn-sm gap-2" do

--- a/app/views/reports/taxes.html.haml
+++ b/app/views/reports/taxes.html.haml
@@ -1,5 +1,4 @@
 - content_for :title, "Tax Report"
-- content_for :page_title, "Tax Report"
 
 .flex.justify-end.mb-6
   = link_to reports_path, class: "btn btn-ghost btn-sm gap-2" do

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -1,3 +1,4 @@
+- content_for :title, "Login"
 .flex.min-h-full.flex-col.justify-center.px-6.py-12.lg:px-8
   .sm:mx-auto.sm:w-full.sm:max-w-sm
     %h2.mt-10.text-center.text-2xl.font-bold.leading-9.tracking-tight.text-base-content

--- a/app/views/tenants/edit.html.haml
+++ b/app/views/tenants/edit.html.haml
@@ -1,3 +1,4 @@
+- content_for :title, "Edit Tenant"
 .max-w-lg.mx-auto
   %h2.text-xl.font-bold.mb-5 Editing Tenant
   = render 'form', tenant: @tenant

--- a/app/views/tenants/index.html.haml
+++ b/app/views/tenants/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title, "Tenants"
+- content_for :title, "Tenants"
 
 - content_for :page_actions do
   -# View toggle (desktop only)

--- a/app/views/tenants/new.html.haml
+++ b/app/views/tenants/new.html.haml
@@ -1,3 +1,4 @@
+- content_for :title, "New Tenant"
 .max-w-lg.mx-auto
   %h2.text-xl.font-bold.mb-5 New Tenant
   = render 'form', tenant: @tenant

--- a/app/views/tenants/show.html.haml
+++ b/app/views/tenants/show.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title, @tenant.name
+- content_for :title, @tenant.name
 
 - content_for :page_actions do
   - if policy(@tenant).edit?

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,3 +1,4 @@
+- content_for :title, "Edit User"
 .max-w-lg.mx-auto
   %h2.text-xl.font-bold.mb-5 Editing User
   = render 'form', user: @user

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title, "Users"
+- content_for :title, "Users"
 
 - content_for :page_actions do
   -# View toggle (desktop only) - defaults to table view

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -1,3 +1,4 @@
+- content_for :title, "New User"
 .max-w-lg.mx-auto
   %h2.text-xl.font-bold.mb-5 New User
   = render 'form', user: @user

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title, @user.name
+- content_for :title, @user.name
 
 - content_for :page_actions do
   - if policy(@user).edit?

--- a/app/views/versions/index.html.haml
+++ b/app/views/versions/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title, t(".title")
+- content_for :title, t(".title")
 
 - content_for :page_actions do
   -# No view toggle - audit trail is table-only

--- a/app/views/versions/show.html.haml
+++ b/app/views/versions/show.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title do
+- content_for :title do
   = t(".title")
   %span.text-base.font-normal.opacity-60.ml-2 ##{@version.id}
 

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Reports" do
       end
 
       it { expect(response).to have_http_status(:success) }
-      it { expect(response.body).to include("Financial Dashboard") }
+      it { expect(response.body).to include("Overview") }
     end
 
     context "when authenticated as admin" do


### PR DESCRIPTION
## Summary
- Unify `:title` and `:page_title` into a single `:title` content block — used for both the HTML `<title>` tag (via `strip_tags`) and the H1 page heading
- Add `content_for :title` to all new/edit views and the login page that were missing it
- Remove the now-unused `:page_title` content block entirely

## Test plan
- [x] 566 specs pass, 0 failures
- [ ] Navigate through all pages and verify browser tab shows correct title
- [ ] Check browser history shows distinct page names instead of "Lease Manager" everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)