### PR TITLE
feat: Cloudflare Worker proxy for custom domain routing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,10 @@ jobs:
             -auto-approve \
             -var "project_id=${{ env.GCP_PROJECT_ID }}" \
             -var "region=${{ env.GCP_REGION }}" \
-            -var "image_tag=${{ github.sha }}"
+            -var "image_tag=${{ github.sha }}" \
+            -var "cloudflare_api_token=${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+            -var "cloudflare_account_id=${{ vars.CLOUDFLARE_ACCOUNT_ID }}" \
+            -var "cloudflare_zone_id=${{ vars.CLOUDFLARE_ZONE_ID }}"
 
       - name: Run database migrations
         run: |

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -149,6 +149,15 @@ module "app" {
   ]
 }
 
+module "cloudflare" {
+  source               = "./modules/cloudflare"
+  cloudflare_account_id = var.cloudflare_account_id
+  cloudflare_zone_id    = var.cloudflare_zone_id
+  cloud_run_host        = replace(module.app.cloud_run_url, "https://", "")
+
+  depends_on = [module.app]
+}
+
 module "scheduler" {
   source               = "./modules/scheduler"
   project_id           = var.project_id

--- a/infra/modules/cloudflare/main.tf
+++ b/infra/modules/cloudflare/main.tf
@@ -1,0 +1,47 @@
+resource "cloudflare_workers_script" "proxy" {
+  account_id = var.cloudflare_account_id
+  script_name = "lease-manager-proxy"
+
+  content = <<-JS
+    const ORIGIN = "${var.cloud_run_host}";
+
+    export default {
+      async fetch(request) {
+        const url = new URL(request.url);
+        const originalHost = url.hostname;
+        url.hostname = ORIGIN;
+        url.protocol = "https:";
+
+        const headers = new Headers(request.headers);
+        headers.set("Host", ORIGIN);
+        headers.set("X-Forwarded-Host", originalHost);
+
+        return fetch(url.toString(), {
+          method: request.method,
+          headers,
+          body: request.body,
+          redirect: "manual",
+        });
+      },
+    };
+  JS
+
+  compatibility_date = "2025-01-01"
+  main_module        = "worker.js"
+}
+
+resource "cloudflare_dns_record" "lease_manager" {
+  zone_id = var.cloudflare_zone_id
+  name    = "lease-manager"
+  type    = "CNAME"
+  content = var.cloud_run_host
+  proxied = true
+  ttl     = 1
+  comment = "Proxied via Cloudflare Worker to Cloud Run"
+}
+
+resource "cloudflare_workers_route" "proxy" {
+  zone_id = var.cloudflare_zone_id
+  pattern = "lease-manager.loonyb.in/*"
+  script  = cloudflare_workers_script.proxy.script_name
+}

--- a/infra/modules/cloudflare/variables.tf
+++ b/infra/modules/cloudflare/variables.tf
@@ -1,0 +1,14 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID for loonyb.in"
+  type        = string
+}
+
+variable "cloud_run_host" {
+  description = "Cloud Run service hostname (e.g. lease-manager-xxx.asia-south1.run.app)"
+  type        = string
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6"
     }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
   }
 
   backend "gcs" {
@@ -21,4 +25,8 @@ terraform {
 provider "google" {
   project = var.project_id
   region  = var.region
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -25,3 +25,19 @@ variable "db_tier" {
   type        = string
   default     = "db-f1-micro"
 }
+
+variable "cloudflare_api_token" {
+  description = "Cloudflare API token with Workers permissions"
+  type        = string
+  sensitive   = true
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID for loonyb.in"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- Cloud Run in `asia-south1` doesn't support domain mapping, causing `lease-manager.loonyb.in` to return Google 404s
- Adds a Cloudflare Worker (managed via OpenTofu) that proxies requests with the correct `Host` header to Cloud Run
- Includes `cloudflare_dns_record` for the CNAME and `cloudflare_workers_route` for routing

## Test plan
- [x] Verified `curl https://lease-manager.loonyb.in/up` returns healthy response
- [x] Confirmed `cf-ray` and `x-request-id` headers present in responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)