### PR TITLE
fix: add required_providers to Cloudflare module

### DIFF
--- a/infra/modules/cloudflare/main.tf
+++ b/infra/modules/cloudflare/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+}
+
 resource "cloudflare_workers_script" "proxy" {
   account_id = var.cloudflare_account_id
   script_name = "lease-manager-proxy"


### PR DESCRIPTION
## Summary
- The Cloudflare module lacked a `required_providers` block, causing its resources to resolve to the implicit `hashicorp/cloudflare` provider instead of the configured `cloudflare/cloudflare`
- This left resources using an unconfigured provider with no API token, causing "Missing Authorization headers" errors on every deploy
- State was migrated via `tofu state replace-provider` to match

## Test plan
- [x] `tofu plan` succeeds locally with token from tfvars
- [x] Cloudflare state refresh completes without auth errors
- [ ] Full deploy succeeds on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)