### PR TITLE
fix: use cron expression for recurring invoice schedule

### DIFF
--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -15,4 +15,4 @@ production:
     schedule: every hour at minute 12
   generate_monthly_invoices:
     command: "GenerateInvoicesJob.perform_later"
-    schedule: on the 1st of every month at 00:05
+    schedule: "5 0 1 * *"


### PR DESCRIPTION
## Summary
- Fixes worker crash caused by invalid schedule format in `recurring.yml`
- Solid Queue uses Fugit which requires cron syntax, not natural language strings
- Changes `on the 1st of every month at 00:05` → `5 0 1 * *`

## Test plan
- [ ] Deploy and confirm worker starts without errors
- [ ] Verify task is registered: `dokku run lease-manager bundle exec rails runner "pp SolidQueue::RecurringTask.all.map(&:key)"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)